### PR TITLE
Use https URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "zkevm-contracts"]
 	path = zkevm-contracts
-	url = git@github.com:EspressoSystems/zkevm-contracts.git
+	url = https://github.com/EspressoSystems/zkevm-contracts.git
 [submodule "zkevm-node"]
 	path = zkevm-node
-	url = git@github.com:EspressoSystems/zkevm-node.git
+	url = https://github.com/EspressoSystems/zkevm-node.git


### PR DESCRIPTION
Enables cloning the repo without having github SSH keys configured.