### PR TITLE
Deal with postgres better

### DIFF
--- a/docker/state-db.Dockerfile
+++ b/docker/state-db.Dockerfile
@@ -1,6 +1,7 @@
 FROM postgres:15
-ENV POSTGRES_USER=state_user
-ENV POSTGRES_PASSWORD=state_password
-ENV POSTGRES_DB=state_db
+ENV POSTGRES_USER=postgres
+ENV POSTGRES_PASSWORD=root_password
+ENV POSTGRES_DB=unused
 ADD ./zkevm-node/db/scripts/init_prover_db.sql /docker-entrypoint-initdb.d/1.sql
 ADD ./zkevm-node-additions/init_pool_db.sql /docker-entrypoint-initdb.d/2.sql
+ADD ./zkevm-node-additions/init_state_db.sql /docker-entrypoint-initdb.d/3.sql

--- a/zkevm-node-additions/init_pool_db.sql
+++ b/zkevm-node-additions/init_pool_db.sql
@@ -2,3 +2,7 @@
 -- created via the `POSTGRES_DB` environment variable passed to the docker
 -- container.
 CREATE DATABASE pool_db;
+\connect pool_db;
+CREATE USER pool_user with password 'pool_password';
+GRANT ALL ON SCHEMA public TO pool_user;
+GRANT ALL ON DATABASE pool_db TO pool_user WITH GRANT OPTION;

--- a/zkevm-node-additions/init_state_db.sql
+++ b/zkevm-node-additions/init_state_db.sql
@@ -1,0 +1,8 @@
+-- Create the database for the state. In the combined database, this DB is not
+-- created via the `POSTGRES_DB` environment variable passed to the docker
+-- container.
+CREATE DATABASE state_db;
+\connect state_db;
+CREATE USER state_user with password 'state_password';
+GRANT ALL ON SCHEMA public TO state_user;
+GRANT ALL ON DATABASE state_db TO state_user WITH GRANT OPTION;


### PR DESCRIPTION
We were using root credentials for postgres in services.
- Create root creds that won't be used
- Don't create database we are using by default
- Create all users and dbs in init .sql files
- Set user permissions there as well