### PR TITLE
Deploy script fixes

### DIFF
--- a/zkevm-contract-bindings/src/bin/deploy.rs
+++ b/zkevm-contract-bindings/src/bin/deploy.rs
@@ -10,13 +10,12 @@ use async_compatibility_layer::logging::{setup_backtrace, setup_logging};
 use clap::Parser;
 use contract_bindings::HotShot;
 use ethers::{
-    prelude::SignerMiddleware,
     providers::{Http, Middleware, Provider},
-    signers::{coins_bip39::English, LocalWallet, MnemonicBuilder, Signer},
     types::Address,
     utils::{get_contract_address, parse_ether},
 };
 use hex::{FromHex, FromHexError};
+use sequencer_utils::{connect_rpc, Middleware as EthMiddleware};
 use serde::{Deserialize, Serialize};
 use serde_with::with_prefix;
 use std::path::PathBuf;
@@ -28,8 +27,6 @@ use zkevm_contract_bindings::{
     shared_types::InitializePackedParameters,
     verifier_rollup_helper_mock::VerifierRollupHelperMock, Deploy, PolygonZkEVM,
 };
-
-pub type EthMiddleware = SignerMiddleware<Provider<Http>, LocalWallet>;
 
 /// A script to deploy all contracts for the demo to an Ethereum RPC.
 ///
@@ -131,7 +128,7 @@ struct ZkEvmDeploymentOutput {
     /// The address of the bridge contract.
     bridge_address: Address,
     /// The address of the global exit root contract.
-    global_exit_root_address: Address,
+    ger_address: Address,
     /// The address of the verifier contract.
     verifier_address: Address,
     /// The block number when the rollup contract was deployed.
@@ -174,13 +171,14 @@ async fn deploy_zkevm(
 ) -> Result<ZkEvmDeploymentOutput> {
     let (_, verifier) = VerifierRollupHelperMock::deploy_contract(&deployer, ()).await;
 
+    let deployer_address = deployer.inner().address();
     let matic_token_initial_balance = parse_ether("20000000")?;
     let (_, matic) = ERC20PermitMock::deploy_contract(
         &deployer,
         (
             "Matic Token".to_string(),
             "MATIC".to_string(),
-            deployer.address(),
+            deployer_address,
             matic_token_initial_balance,
         ),
     )
@@ -188,10 +186,10 @@ async fn deploy_zkevm(
 
     // We need to pass the addresses to the GER constructor.
     let nonce = provider
-        .get_transaction_count(deployer.address(), None)
+        .get_transaction_count(deployer.inner().address(), None)
         .await?;
-    let precalc_bridge_address = get_contract_address(deployer.address(), nonce + 1);
-    let precalc_rollup_address = get_contract_address(deployer.address(), nonce + 2);
+    let precalc_bridge_address = get_contract_address(deployer_address, nonce + 1);
+    let precalc_rollup_address = get_contract_address(deployer_address, nonce + 2);
     let (_, global_exit_root) = PolygonZkEVMGlobalExitRoot::deploy_contract(
         &deployer,
         (precalc_rollup_address, precalc_bridge_address),
@@ -244,7 +242,7 @@ async fn deploy_zkevm(
     rollup
         .initialize(
             InitializePackedParameters {
-                admin: deployer.address(),
+                admin: deployer_address,
                 trusted_sequencer: Address::zero(), // Not used.
                 pending_state_timeout: 10,
                 trusted_aggregator: *trusted_aggregator,
@@ -263,7 +261,7 @@ async fn deploy_zkevm(
         rollup_address: rollup.address(),
         bridge_address: bridge.address(),
         matic_address: matic.address(),
-        global_exit_root_address: global_exit_root.address(),
+        ger_address: global_exit_root.address(),
         verifier_address: verifier.address(),
         genesis_block_number,
     })
@@ -272,15 +270,10 @@ async fn deploy_zkevm(
 async fn deploy(opts: Options) -> Result<()> {
     let mut provider = Provider::try_from(opts.provider_url.to_string())?;
     provider.set_interval(Duration::from_millis(100));
-    let chain_id = provider.get_chainid().await?.as_u64();
-    let deployer = Arc::new(SignerMiddleware::new(
-        provider.clone(),
-        MnemonicBuilder::<English>::default()
-            .phrase(opts.mnemonic.as_str())
-            .index(0u32)?
-            .build()?
-            .with_chain_id(chain_id),
-    ));
+    let deployer = connect_rpc(&opts.provider_url, &opts.mnemonic, 0, None)
+        .await
+        .unwrap();
+    tracing::info!("Using deployer account {:?}", deployer.inner().address());
 
     // Deploy the hotshot contract.
     let hotshot = HotShot::deploy(deployer.clone(), ())?.send().await?;


### PR DESCRIPTION
- Use a nonce manager to avoid failing if infura returns incosistent nonces.
- Fix the env var name for the global exit root. This is from the preconfirmations PR, but not sure when we will merge that.

https://github.com/EspressoSystems/espresso-polygon-zkevm-demo/pull/105/files#diff-562c8b0970a4da9353b0f3747ba0211845b51c5af050d8ed227b3d66c3a41e54R135