### PR TITLE
Use websocket provider for subscription only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,6 +3211,7 @@ dependencies = [
  "ethers",
  "futures",
  "polygon-zkevm-adaptor",
+ "portpicker",
  "regex",
  "sequencer-utils",
  "serde",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -17,6 +17,7 @@ async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 clap = "4.3.9"
 ethers = { version = "2.0.7", features = ["ws"] }
 futures = "0.3.28"
+portpicker = "0.1.1"
 regex = "1.8.4"
 serde = "1.0.164"
 serenity = { version = "0.11", default-features = false, features = [


### PR DESCRIPTION
- Use HTTP provider for queries.
- Add test for reconnection.
- Restart websocket subscription if connection closed.