### PR TITLE
Fix slow tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,18 @@ jobs:
         run: |
           cargo build --release --workspace
 
+      - name: Install PNPM
+        uses: pnpm/action-setup@v2
+        # PNPM is only needed for the slow tests, which we don't run in the PR workflow.
+        if: github.event_name != 'pull_request'
+        with:
+          version: 8
+
+      - name: Install Node Packages
+        # PNPM is only needed for the slow tests, which we don't run in the PR workflow.
+        if: github.event_name != 'pull_request'
+        run: pnpm install
+
       - name: Include Slow Tests
         if: github.event_name != 'pull_request'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6141,17 +6141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
 name = "nll"
 version = "1.0.0"
 source = "git+https://github.com/EspressoSystems/nll#8e7926789f8eb464cbbbb1858ba4292a6ec6d900"
@@ -6725,7 +6714,6 @@ dependencies = [
  "hotshot-types",
  "http-types",
  "jsonrpc-v2",
- "nix 0.27.1",
  "portpicker",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -7494,7 +7482,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.3",
+ "nix",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6141,6 +6141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nll"
 version = "1.0.0"
 source = "git+https://github.com/EspressoSystems/nll#8e7926789f8eb464cbbbb1858ba4292a6ec6d900"
@@ -6714,6 +6725,7 @@ dependencies = [
  "hotshot-types",
  "http-types",
  "jsonrpc-v2",
+ "nix 0.27.1",
  "portpicker",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -7482,7 +7494,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]

--- a/docker-compose-anvil.yaml
+++ b/docker-compose-anvil.yaml
@@ -17,4 +17,4 @@ services:
 
     stop_signal: SIGKILL
     healthcheck:
-      test: ["CMD", "cast", "chain-id"]
+      test: ["CMD", "cast", "chain-id", "-r", "http://localhost:$ESPRESSO_ZKEVM_L1_PORT"]

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ demo-profiles *args:
     scripts/source-dotenv .env.geth scripts/demo-with-profiles {{args}}
 
 down *args:
-   {{compose}} down {{args}}
+   {{compose}} down --remove-orphans {{args}}
 
 pull:
     {{compose-anvil}} pull && {{compose}} pull

--- a/polygon-zkevm-adaptor/Cargo.toml
+++ b/polygon-zkevm-adaptor/Cargo.toml
@@ -18,7 +18,7 @@ name = "load-test-deployment"
 required-features = ["testing"]
 
 [features]
-testing = ["portpicker"]
+testing = ["portpicker", "rand", "snafu"]
 slow-tests = []
 
 [dependencies]
@@ -38,6 +38,7 @@ http-types = "2.12.0"
 jsonrpc-v2 = "0.11.0"
 sequencer = { git = "https://github.com/EspressoSystems/espresso-sequencer.git" }
 sequencer-utils = { git = "https://github.com/EspressoSystems/espresso-sequencer.git" }
+serde = "1.0"
 serde_json = "1.0.82"
 surf = "2.3.2"
 surf-disco = { git = "https://github.com/EspressoSystems/surf-disco", tag = "v0.4.3" }
@@ -50,16 +51,17 @@ zkevm-contract-bindings = { path = "../zkevm-contract-bindings" }
 
 # Dependencies for feature "testing".
 portpicker = { version = "0.1", optional = true }
-rand = "0.8.5"
-serde = "1.0.163"
-snafu = "0.7.4"
+rand = { version = "0.8", optional = true }
+snafu = { version = "0.7", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 commit = { git = "https://github.com/EspressoSystems/commit" }
 portpicker = "0.1"
+rand = "0.8"
 rand_chacha = "0.3"
 sequencer = { git = "https://github.com/EspressoSystems/espresso-sequencer.git", features = [
     "testing",
 ] }
+snafu = "0.7"
 tempfile = "3.4.0"

--- a/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
+++ b/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
@@ -119,7 +119,9 @@ impl SequencerZkEvmDemo {
             .arg("standalone-docker-compose.yaml")
             .arg("-f")
             .arg(layer1_backend.compose_file())
-            .args(["-f", "docker-compose.yaml"]);
+            .args(["-f", "docker-compose.yaml"])
+            .args(["--profile", "zkevm1"])
+            .args(["--profile", "zkevm1-preconfirmations"]);
         cmd
     }
 

--- a/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
+++ b/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
@@ -130,7 +130,7 @@ impl SequencerZkEvmDemo {
         project_name: String,
         opt: SequencerZkEvmDemoOptions,
     ) -> Self {
-        let mut env = ZkEvmEnv::random();
+        let mut env = ZkEvmEnv::from_dotenv();
 
         tracing::info!("Starting ZkEvmNode with env: {:?}", env);
         tracing::info!(

--- a/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
+++ b/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
@@ -160,7 +160,7 @@ impl SequencerZkEvmDemo {
             .arg("up")
             .args(L1_SERVICES)
             .arg("-V")
-            .arg("--abort-on-container-exit")
+            .arg("--wait")
             .spawn()
             .expect("Failed to start L1 docker container");
 
@@ -211,7 +211,7 @@ impl SequencerZkEvmDemo {
             .args(L2_SERVICES)
             .arg("-V")
             .arg("--no-recreate")
-            .arg("--abort-on-container-exit")
+            .arg("--wait")
             .spawn()
             .expect("Failed to start compose environment");
 

--- a/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
+++ b/polygon-zkevm-adaptor/src/demo_with_sequencer.rs
@@ -122,7 +122,7 @@ impl SequencerZkEvmDemo {
         project_name: String,
         opt: SequencerZkEvmDemoOptions,
     ) -> Self {
-        let mut env = ZkEvmEnv::from_dotenv();
+        let mut env = ZkEvmEnv::random();
 
         tracing::info!("Starting ZkEvmNode with env: {:?}", env);
         tracing::info!(

--- a/polygon-zkevm-adaptor/src/polygon_zkevm.rs
+++ b/polygon-zkevm-adaptor/src/polygon_zkevm.rs
@@ -45,7 +45,9 @@ pub struct ZkEvmEnv {
     l1_provider: Url,
     l1_ws_provider: Url,
     l2_port: u16,
+    l2_ws_port: u16,
     l2_preconfirmations_port: u16,
+    l2_preconfirmations_ws_port: u16,
     l1_chain_id: Option<u64>,
     l2_chain_id: Option<u64>,
     sequencer_mnemonic: String,
@@ -67,7 +69,9 @@ impl Default for ZkEvmEnv {
             l1_provider: "http://demo-l1-network:8545".parse().unwrap(),
             l1_ws_provider: "ws://demo-l1-network:8546".parse().unwrap(),
             l2_port: 18126,
+            l2_ws_port: 18133,
             l2_preconfirmations_port: 18127,
+            l2_preconfirmations_ws_port: 18134,
             l1_chain_id: None,
             l2_chain_id: None,
             sequencer_mnemonic: TEST_MNEMONIC.into(),
@@ -87,7 +91,9 @@ impl ZkEvmEnv {
         let l1_provider = format!("http://demo-l1-network:{l1_port}").parse().unwrap();
         let l1_ws_provider = format!("ws://demo-l1-network:{l1_port}").parse().unwrap();
         let l2_port = pick_unused_port().unwrap();
+        let l2_ws_port = pick_unused_port().unwrap();
         let l2_preconfirmations_port = pick_unused_port().unwrap();
+        let l2_preconfirmations_ws_port = pick_unused_port().unwrap();
         let adaptor_rpc_port = pick_unused_port().unwrap();
         let adaptor_query_port = pick_unused_port().unwrap();
 
@@ -108,7 +114,9 @@ impl ZkEvmEnv {
             l1_provider,
             l1_ws_provider,
             l2_port,
+            l2_ws_port,
             l2_preconfirmations_port,
+            l2_preconfirmations_ws_port,
             l1_chain_id,
             l2_chain_id,
             adaptor_rpc_port,
@@ -138,7 +146,11 @@ impl ZkEvmEnv {
             l1_provider: format!("http://demo-l1-network:{l1_port}").parse().unwrap(),
             l1_ws_provider: format!("ws://demo-l1-network:{l1_port}").parse().unwrap(),
             l2_port: dotenv["ESPRESSO_ZKEVM_1_L2_PORT"].parse().unwrap(),
+            l2_ws_port: dotenv["ESPRESSO_ZKEVM_1_L2_PORT_WS"].parse().unwrap(),
             l2_preconfirmations_port: dotenv["ESPRESSO_ZKEVM_1_PRECONFIRMATIONS_L2_PORT"]
+                .parse()
+                .unwrap(),
+            l2_preconfirmations_ws_port: dotenv["ESPRESSO_ZKEVM_1_PRECONFIRMATIONS_L2_PORT_WS"]
                 .parse()
                 .unwrap(),
             l1_chain_id: None,
@@ -191,9 +203,14 @@ impl ZkEvmEnv {
         .env("ESPRESSO_ZKEVM_L1_PORT", self.l1_port.to_string())
         .env("ESPRESSO_ZKEVM_L1_PROVIDER", self.l1_provider.as_ref())
         .env("ESPRESSO_ZKEVM_1_L2_PORT", self.l2_port.to_string())
+        .env("ESPRESSO_ZKEVM_1_L2_PORT_WS", self.l2_ws_port.to_string())
         .env(
             "ESPRESSO_ZKEVM_1_PRECONFIRMATIONS_L2_PORT",
             self.l2_preconfirmations_port.to_string(),
+        )
+        .env(
+            "ESPRESSO_ZKEVM_1_PRECONFIRMATIONS_L2_PORT_WS",
+            self.l2_preconfirmations_ws_port.to_string(),
         )
         .env(
             "ESPRESSO_ZKEVM_1_L2_PROVIDER",

--- a/polygon-zkevm-adaptor/src/polygon_zkevm.rs
+++ b/polygon-zkevm-adaptor/src/polygon_zkevm.rs
@@ -53,6 +53,7 @@ pub struct ZkEvmEnv {
     sequencer_mnemonic: String,
     adaptor_rpc_port: u16,
     adaptor_query_port: u16,
+    faucet_port: u16,
 }
 
 pub const TEST_MNEMONIC: &str = "test test test test test test test test test test test junk";
@@ -77,6 +78,7 @@ impl Default for ZkEvmEnv {
             sequencer_mnemonic: TEST_MNEMONIC.into(),
             adaptor_rpc_port: 8127,
             adaptor_query_port: 50100,
+            faucet_port: 18111,
         }
     }
 }
@@ -96,6 +98,7 @@ impl ZkEvmEnv {
         let l2_preconfirmations_ws_port = pick_unused_port().unwrap();
         let adaptor_rpc_port = pick_unused_port().unwrap();
         let adaptor_query_port = pick_unused_port().unwrap();
+        let faucet_port = pick_unused_port().unwrap();
 
         // Use default values for things that are deterministic or internal to a docker-compose
         // service.
@@ -123,6 +126,7 @@ impl ZkEvmEnv {
             adaptor_query_port,
             sequencer_storage_path,
             sequencer_mnemonic,
+            faucet_port,
         }
     }
 
@@ -160,6 +164,7 @@ impl ZkEvmEnv {
             adaptor_query_port: dotenv["ESPRESSO_ZKEVM_1_ADAPTOR_QUERY_PORT"]
                 .parse()
                 .unwrap(),
+            faucet_port: dotenv["ESPRESSO_ZKEVM_1_FAUCET_PORT"].parse().unwrap(),
         }
     }
 
@@ -235,6 +240,15 @@ impl ZkEvmEnv {
         .env(
             "ESPRESSO_ZKEVM_1_ADAPTOR_QUERY_URL",
             format!("http://polygon-zkevm-1-adaptor:{}", self.adaptor_query_port).as_str(),
+        )
+        .env("ESPRESSO_ZKEVM_1_FAUCET_PORT", self.faucet_port.to_string())
+        .env(
+            "ESPRESSO_ZKEVM_1_FAUCET_WEB3_PROVIDER_URL_WS",
+            format!("ws://zkevm-1-permissionless-node:{}", self.l2_ws_port),
+        )
+        .env(
+            "ESPRESSO_ZKEVM_1_FAUCET_WEB3_PROVIDER_URL_HTTP",
+            format!("http://zkevm-1-permissionless-node:{}", self.l2_port),
         );
         if let Some(id) = self.l1_chain_id {
             cmd.env("ESPRESSO_ZKEVM_L1_CHAIN_ID", id.to_string());


### PR DESCRIPTION
* Install node packages before running slow tests
* ~~Use randomized ports~~
* Fix shutdown, to prevent issues when services from one test are still running when the next test starts
* Work around an issue in `reorgme` where sometimes the chain ID is briefly incorrect at startup