### PR TITLE
Fix contract deployment script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6103,9 +6103,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -9932,6 +9932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10036,11 +10042,12 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 

--- a/scripts/build-l1-image
+++ b/scripts/build-l1-image
@@ -61,12 +61,32 @@ echo "Funding accounts."
 while read address; do
     # Retry a few times because sending transactions may still fail for a while
     # after the RPC is up.
+    status=1
     for try in $(seq 1 5); do
         echo "Transfer from coinbase to $address"
+        set +e
         geth --exec \
-            "eth.sendTransaction({from: eth.coinbase, to: \"$address\", value: \"10000000000000000000000000000000000000000\"})" \
-            attach http://localhost:$RPC_PORT && break || sleep "$BLOCK_PERIOD";
+            "eth.sendTransaction({from: eth.accounts[0], to: \"$address\", value: \"10000000000000000000000000000000000000000\"})" \
+            attach http://localhost:$RPC_PORT
+        status=$?
+        set -e
+        if [[ $status == 0 ]]; then
+            balance=`cast balance $address -r http://localhost:$RPC_PORT`
+            echo "balance: $balance"
+            if [[ $balance == 0 ]]; then
+                status=1
+                sleep "$BLOCK_PERIOD"
+            else
+                break
+            fi
+        else
+            sleep "$BLOCK_PERIOD"
+        fi
     done
+    if [[ $status != 0 ]]; then
+        echo "failed to fund $address"
+        exit $status
+    fi
 done <<EOF
 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
@@ -92,10 +112,21 @@ EOF
 
 # Deploy the contracts. Retry a few times because sending transactions may fail
 # for a while after having funded the account.
+status=1
 for try in $(seq 1 5); do
     echo "Attempting contract deployment."
-    cargo run --bin deploy -- --provider-url $RPC_URL -o .env.geth && break || sleep 1;
+    set +e
+    cargo run --bin deploy -- --provider-url $RPC_URL -o .env.geth
+    status=$?
+    set -e
+    if [[ $status == 0 ]]; then
+        break
+    fi
 done
+if [[ $status != 0 ]]; then
+    echo "Failed to deploy contract"
+    exit $status
+fi
 
 echo "Contract deployment completed."
 echo "ESPRESSO_ZKEVM_L1_BLOCK_PERIOD=$BLOCK_PERIOD" >> .env.geth


### PR DESCRIPTION
* Exit if retry loops fail
* Fail if we fail to fund one of the prefunded accounts
* Use `eth.accounts[0]` rather than `eth.coinbase`, for some reason the latter no longer works