### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         name: Checkout Repository
         with:
           submodules: true

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v22
@@ -57,7 +57,7 @@ jobs:
       zkevm-adaptor-tag: ${{ steps.polygon-zkevm-adaptor.outputs.tags }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Download executables
         uses: actions/download-artifact@v3

--- a/.github/workflows/compose-end-to-end-test.yml
+++ b/.github/workflows/compose-end-to-end-test.yml
@@ -35,7 +35,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         name: Checkout Repository
         with:
           submodules: true

--- a/.github/workflows/contracts-docker.yml
+++ b/.github/workflows/contracts-docker.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         name: Checkout Repository
         with:
           submodules: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global --add safe.directory /__w/espresso-polygon-zkevm-demo/espresso-polygon-zkevm-demo/zkevm-contracts
           git config --global --add safe.directory /__w/espresso-polygon-zkevm-demo/espresso-polygon-zkevm-demo/zkevm-node
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         name: Checkout Repository
         with:
           submodules: true

--- a/.github/workflows/postgres-docker.yml
+++ b/.github/workflows/postgres-docker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: true
 

--- a/.github/workflows/update_nix.yml
+++ b/.github/workflows/update_nix.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: cachix/install-nix-action@v22

--- a/.github/workflows/zkevm-dockers.yml
+++ b/.github/workflows/zkevm-dockers.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: true
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0